### PR TITLE
Modernize terminfo handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ xt5250
 *~
 *.scc
 autom4te.cache/
+termcap/*/5/
+termcap/*/x/

--- a/configure.ac
+++ b/configure.ac
@@ -36,12 +36,12 @@ AC_CACHE_CHECK([whether to use old key handler],
     [ac_cv_use_old_keys=no])
 
 AC_ARG_WITH([terminfo],
-    AS_HELP_STRING([--with-terminfo],[install terminfo entries for your platform (default=yes)]),
+    AS_HELP_STRING([--with-terminfo],[install terminfo entries for your platform (default=no)]),
     [ac_cv_install_terminfo=$withval],
-    [ac_cv_install_terminfo=yes])
+    [ac_cv_install_terminfo=no])
 AC_CACHE_CHECK([whether to install terminfo entries],
     [ac_cv_install_terminfo],
-    [ac_cv_install_terminfo=yes])
+    [ac_cv_install_terminfo=no])
 AM_CONDITIONAL([INSTALL_TERMINFO], [test "$ac_cv_install_terminfo" = "yes"])
 
 # run AC_CHECK_LIB this way to avoid linking curses into every executable

--- a/configure.ac
+++ b/configure.ac
@@ -27,7 +27,22 @@ AC_CHECK_HEADERS([fcntl.h locale.h sys/wait.h sys/time.h syslog.h unistd.h pwd.h
 AC_DEFINE_UNQUOTED(SOCKET_TYPE,int)
 
 # User specified optional packages
-AC_ARG_WITH([curses-old-keys],AS_HELP_STRING([--with-curses-old-keys],[curses terminal will use old key handler (default=no)]),[ac_cv_use_old_keys=$withval],[ac_cv_use_old_keys=no]) AC_CACHE_CHECK([whether to use old key handler],[ac_cv_use_old_keys], [ac_cv_use_old_keys=no])
+AC_ARG_WITH([curses-old-keys],
+    AS_HELP_STRING([--with-curses-old-keys],[curses terminal will use old key handler (default=no)]),
+    [ac_cv_use_old_keys=$withval],
+    [ac_cv_use_old_keys=no])
+AC_CACHE_CHECK([whether to use old key handler],
+    [ac_cv_use_old_keys],
+    [ac_cv_use_old_keys=no])
+
+AC_ARG_WITH([terminfo],
+    AS_HELP_STRING([--with-terminfo],[install terminfo entries for your platform (default=yes)]),
+    [ac_cv_install_terminfo=$withval],
+    [ac_cv_install_terminfo=yes])
+AC_CACHE_CHECK([whether to install terminfo entries],
+    [ac_cv_install_terminfo],
+    [ac_cv_install_terminfo=yes])
+AM_CONDITIONAL([INSTALL_TERMINFO], [test "$ac_cv_install_terminfo" = "yes"])
 
 # run AC_CHECK_LIB this way to avoid linking curses into every executable
 AC_CHECK_LIB(ncurses, initscr, CURSES_LIBS=-lncurses)

--- a/configure.ac
+++ b/configure.ac
@@ -85,6 +85,21 @@ fi
 
 AC_SUBST([CURSES_LIBS])
 
+dnl Host-specific terminal information; these often are based on the OS's built
+dnl in console terminal capabilities, so they aren't portable. Especially if
+dnl they differ between termcap vs. terminfo...
+dnl
+dnl XXX: Is the Linux terminfo entry geneerally useful?
+dnl XXX: Currently, only Linux is refactored to not trample system directories.
+dnl FreeBSD termcap needs refactoring, Solaris makefiles don't install.
+case "${host_os}" in
+    linux*)
+        ac_cv_build_linux=yes
+        ;;
+esac
+
+AM_CONDITIONAL([LINUX], [test "$ac_cv_build_linux" = "yes"])
+
 AC_CONFIG_FILES([Makefile
 		 curses/Makefile
 		 doc/Makefile

--- a/termcaps/freebsd/Makefile.am
+++ b/termcaps/freebsd/Makefile.am
@@ -10,6 +10,7 @@ pkgdata_DATA	= us.5250.kbd \
 
 bin_SCRIPTS 	= 5250keys
 
+if INSTALL_TERMINFO
 #
 # here we install our termcap entry 
 #
@@ -42,4 +43,4 @@ install-data-local:
 	    echo "** this manually." >&2 ; \
 	    echo "**" >&2 ; \
 	  fi )
-
+endif

--- a/termcaps/linux/Makefile.am
+++ b/termcaps/linux/Makefile.am
@@ -8,6 +8,7 @@ EXTRA_DIST	= 5250.tcap\
 pkgdata_DATA	= uk5250.map\
 		  us5250.map
 
+if INSTALL_TERMINFO
 if LINUX
 all: 5/5250 x/xterm-5250
 
@@ -28,4 +29,5 @@ uninstall-local:
 
 clean-local:
 	rm -rf ./5 ./x
+endif
 endif

--- a/termcaps/linux/Makefile.am
+++ b/termcaps/linux/Makefile.am
@@ -8,43 +8,24 @@ EXTRA_DIST	= 5250.tcap\
 pkgdata_DATA	= uk5250.map\
 		  us5250.map
 
-#
-# Here we automagically run tic if we can determine that the system
-# is Linux and we can find the tic command (and make install was
-# run as root).
-#
-install-data-local:
-	@( good=no ; \
-	  if [ "$$(uname -s)" = "Linux" ]; then \
-            if which tic >/dev/null 2>&1 ; then \
-	      if [ "`whoami`" = "root" ]; then \
-		rm -f /usr/share/terminfo/x/xterm-5250 ; \
-		rm -f /usr/share/terminfo/5/5250 ; \
-		rm -f /usr/lib/terminfo/x/xterm-5250 ; \
-		rm -f /usr/lib/terminfo/5/5250 ; \
-		good=yes ; \
-		tic $(srcdir)/5250.terminfo || good=no ; \
-	      else \
-		mkdir -p ~/.terminfo || exit $$? ; \
-		rm -f ~/.terminfo/x/xterm-5250 ; \
-		rm -f ~/.terminfo/5/5250 ; \
-		good=yes ; \
-		tic $(srcdir)/5250.terminfo || good=no ; \
-	      fi ; \
-	    fi ; \
-	  else \
-	    good=yes ; \
-	  fi ; \
-	  if [ x$$good = xno ] ; then \
-	    echo "**" >&2 ; \
-	    echo "** Could not install terminfo entry automatically.  Possible" >&2 ; \
-	    echo "** reasons for this include:" >&2 ; \
-	    echo "**   - Could not find 'tic' command." >&2 ; \
-	    echo "**   - 'make install' was not run as root." >&2 ; \
-	    echo "**" >&2 ; \
-	    echo "** Some keys may not work until this is installed, please read" >&2 ; \
-	    echo "** the linux/README file for instructions on how to install" >&2 ; \
-	    echo "** this manually." >&2 ; \
-	    echo "**" >&2 ; \
-	  fi )
+if LINUX
+all: 5/5250 x/xterm-5250
 
+# XXX: This executes tic twice
+5/5250 x/xterm-5250: 5250.terminfo
+	tic -x -o . $<
+
+# could be /usr/share/terminfo or /usr/lib/terminfo
+install-data-local:
+	$(MKDIR_P) $(DESTDIR)$(datadir)/terminfo/5
+	$(INSTALL_DATA) 5/5250 $(DESTDIR)$(datadir)/terminfo/5/5250
+	$(MKDIR_P) $(DESTDIR)$(datadir)/terminfo/x
+	$(INSTALL_DATA) x/xterm-5250 $(DESTDIR)$(datadir)/terminfo/x/xterm-5250
+
+uninstall-local:
+	rm -f $(DESTDIR)$(datadir)/terminfo/5/5250
+	rm -f $(DESTDIR)$(datadir)/terminfo/x/xterm-5250
+
+clean-local:
+	rm -rf ./5 ./x
+endif


### PR DESCRIPTION
I'm not sure how useful these entries still are in 2025, but...

* The terminfo entries are only installed if `--with-terminfo` is specified; by default, this is true.
* Fixes #14 by not running `tic` on the system terminfo database and installing the generated entries later.

This doesn't update the FreeBSD part yet (not sure if these still work, or how to deal with termcap specifically yet), nor does it add CMake support.