### PR TITLE
Fix Esc/Meta handling

### DIFF
--- a/curses/cursesterm.c
+++ b/curses/cursesterm.c
@@ -1030,9 +1030,6 @@ static int curses_terminal_get_esc_key(Tn5250Terminal* This, int is_esc) {
     move(y, x);
     refresh();
 
-    FD_ZERO(&fdr);
-    FD_SET(0, &fdr);
-    select(1, &fdr, NULL, NULL, NULL);
     key = getch();
 
     if (isalpha(key)) {


### PR DESCRIPTION
Manually waiting for this breaks Meta (Alt)/Esc key handling. If we want to force a delay, then curses has functionality for this.

Fixes #18