### PR TITLE
Cleanup: remove 3270 and server support

### DIFF
--- a/lib5250/printsession.c
+++ b/lib5250/printsession.c
@@ -313,9 +313,9 @@ void tn5250_print_session_main_loop(Tn5250PrintSession* This) {
                         continue;
                     }
 
-                    header.h5250.flowtype = TN5250_RECORD_FLOW_CLIENTO;
-                    header.h5250.flags = TN5250_RECORD_H_NONE;
-                    header.h5250.opcode = TN5250_RECORD_OPCODE_PRINT_COMPLETE;
+                    header.flowtype = TN5250_RECORD_FLOW_CLIENTO;
+                    header.flags = TN5250_RECORD_H_NONE;
+                    header.opcode = TN5250_RECORD_OPCODE_PRINT_COMPLETE;
 
                     tn5250_stream_send_packet(This->stream, 0, header, NULL);
 

--- a/lib5250/session.c
+++ b/lib5250/session.c
@@ -217,9 +217,9 @@ void tn5250_session_send_error(Tn5250Session* This, unsigned long errorcode) {
     errorcode = htonl(errorcode);
 
     TN5250_LOG(("Sending negative response = %x", errorcode));
-    header.h5250.flowtype = TN5250_RECORD_FLOW_DISPLAY;
-    header.h5250.flags = TN5250_RECORD_H_ERR;
-    header.h5250.opcode = TN5250_RECORD_OPCODE_NO_OP;
+    header.flowtype = TN5250_RECORD_FLOW_DISPLAY;
+    header.flags = TN5250_RECORD_H_ERR;
+    header.opcode = TN5250_RECORD_OPCODE_NO_OP;
 
     tn5250_stream_send_packet(This->stream, 4, header,
                               (unsigned char*)&errorcode);
@@ -330,9 +330,9 @@ static void tn5250_session_invite(Tn5250Session* This) {
 static void tn5250_session_cancel_invite(Tn5250Session* This) {
     StreamHeader header;
 
-    header.h5250.flowtype = TN5250_RECORD_FLOW_DISPLAY;
-    header.h5250.flags = TN5250_RECORD_H_NONE;
-    header.h5250.opcode = TN5250_RECORD_OPCODE_CANCEL_INVITE;
+    header.flowtype = TN5250_RECORD_FLOW_DISPLAY;
+    header.flags = TN5250_RECORD_H_NONE;
+    header.opcode = TN5250_RECORD_OPCODE_CANCEL_INVITE;
 
     TN5250_LOG(("CancelInvite: entered.\n"));
     tn5250_display_indicator_set(This->display, TN5250_DISPLAY_IND_X_CLOCK);
@@ -436,9 +436,9 @@ static void tn5250_session_send_fields(Tn5250Session* This, int aidcode) {
     tn5250_display_indicator_clear(This->display, TN5250_DISPLAY_IND_INSERT);
     tn5250_display_update(This->display);
 
-    header.h5250.flowtype = TN5250_RECORD_FLOW_DISPLAY;
-    header.h5250.flags = TN5250_RECORD_H_NONE;
-    header.h5250.opcode = TN5250_RECORD_OPCODE_PUT_GET;
+    header.flowtype = TN5250_RECORD_FLOW_DISPLAY;
+    header.flags = TN5250_RECORD_H_NONE;
+    header.opcode = TN5250_RECORD_OPCODE_PUT_GET;
 
     tn5250_stream_send_packet(This->stream, tn5250_buffer_length(&field_buf),
                               header, tn5250_buffer_data(&field_buf));
@@ -1252,9 +1252,9 @@ static int tn5250_session_handle_aidkey(Tn5250Session* This, int key) {
                                   tn5250_display_cursor_x(This->display) + 1);
         tn5250_buffer_append_byte(&buf, key);
 
-        header.h5250.flowtype = TN5250_RECORD_FLOW_DISPLAY;
-        header.h5250.flags = TN5250_RECORD_H_NONE;
-        header.h5250.opcode = TN5250_RECORD_OPCODE_NO_OP;
+        header.flowtype = TN5250_RECORD_FLOW_DISPLAY;
+        header.flags = TN5250_RECORD_H_NONE;
+        header.opcode = TN5250_RECORD_OPCODE_NO_OP;
 
         tn5250_stream_send_packet(This->stream, tn5250_buffer_length(&buf),
                                   header, tn5250_buffer_data(&buf));
@@ -1263,9 +1263,9 @@ static int tn5250_session_handle_aidkey(Tn5250Session* This, int key) {
 
     case TN5250_SESSION_AID_SYSREQ:
 
-        header.h5250.flowtype = TN5250_RECORD_FLOW_DISPLAY;
-        header.h5250.flags = TN5250_RECORD_H_SRQ;
-        header.h5250.opcode = TN5250_RECORD_OPCODE_NO_OP;
+        header.flowtype = TN5250_RECORD_FLOW_DISPLAY;
+        header.flags = TN5250_RECORD_H_SRQ;
+        header.opcode = TN5250_RECORD_OPCODE_NO_OP;
 
         tn5250_display_indicator_set(This->display,
                                      TN5250_DISPLAY_IND_X_SYSTEM);
@@ -1281,16 +1281,16 @@ static int tn5250_session_handle_aidkey(Tn5250Session* This, int key) {
         break;
 
     case TN5250_SESSION_AID_TESTREQ:
-        header.h5250.flowtype = TN5250_RECORD_FLOW_DISPLAY;
-        header.h5250.flags = TN5250_RECORD_H_TRQ;
-        header.h5250.opcode = TN5250_RECORD_OPCODE_NO_OP;
+        header.flowtype = TN5250_RECORD_FLOW_DISPLAY;
+        header.flags = TN5250_RECORD_H_TRQ;
+        header.opcode = TN5250_RECORD_OPCODE_NO_OP;
         tn5250_stream_send_packet(This->stream, 0, header, NULL);
         break;
 
     case TN5250_SESSION_AID_ATTN:
-        header.h5250.flowtype = TN5250_RECORD_FLOW_DISPLAY;
-        header.h5250.flags = TN5250_RECORD_H_ATN;
-        header.h5250.opcode = TN5250_RECORD_OPCODE_NO_OP;
+        header.flowtype = TN5250_RECORD_FLOW_DISPLAY;
+        header.flags = TN5250_RECORD_H_ATN;
+        header.opcode = TN5250_RECORD_OPCODE_NO_OP;
 
         tn5250_display_indicator_set(This->display,
                                      TN5250_DISPLAY_IND_X_SYSTEM);
@@ -1310,9 +1310,9 @@ static int tn5250_session_handle_aidkey(Tn5250Session* This, int key) {
             unsigned char src[2];
             src[0] = (This->display->keySRC >> 8) & 0xff;
             src[1] = (This->display->keySRC) & 0xff;
-            header.h5250.flowtype = TN5250_RECORD_FLOW_DISPLAY;
-            header.h5250.flags = TN5250_RECORD_H_HLP;
-            header.h5250.opcode = TN5250_RECORD_OPCODE_NO_OP;
+            header.flowtype = TN5250_RECORD_FLOW_DISPLAY;
+            header.flags = TN5250_RECORD_H_HLP;
+            header.opcode = TN5250_RECORD_OPCODE_NO_OP;
             TN5250_LOG(("PreHelp HELP key: %02x %02x\n", src[0], src[1]));
             tn5250_stream_send_packet(This->stream, 2, header, src);
             This->display->keystate = TN5250_KEYSTATE_POSTHELP;
@@ -1393,9 +1393,9 @@ static void tn5250_session_save_screen(Tn5250Session* This) {
         tn5250_buffer_append_byte(&buffer, 0x00); /* FIXME: ? CC2 */
     }
 
-    header.h5250.flowtype = TN5250_RECORD_FLOW_DISPLAY;
-    header.h5250.flags = TN5250_RECORD_H_NONE;
-    header.h5250.opcode = TN5250_RECORD_OPCODE_SAVE_SCR;
+    header.flowtype = TN5250_RECORD_FLOW_DISPLAY;
+    header.flags = TN5250_RECORD_H_NONE;
+    header.opcode = TN5250_RECORD_OPCODE_SAVE_SCR;
 
     tn5250_stream_send_packet(This->stream, tn5250_buffer_length(&buffer),
                               header, tn5250_buffer_data(&buffer));
@@ -1440,9 +1440,9 @@ static void tn5250_session_save_partial_screen(Tn5250Session* This) {
         tn5250_buffer_append_byte(&buffer, 0x00); /* FIXME: ? CC2 */
     }
 
-    header.h5250.flowtype = TN5250_RECORD_FLOW_DISPLAY;
-    header.h5250.flags = TN5250_RECORD_H_NONE;
-    header.h5250.opcode = TN5250_RECORD_OPCODE_SAVE_SCR;
+    header.flowtype = TN5250_RECORD_FLOW_DISPLAY;
+    header.flags = TN5250_RECORD_H_NONE;
+    header.opcode = TN5250_RECORD_OPCODE_SAVE_SCR;
 
     tn5250_stream_send_packet(This->stream, tn5250_buffer_length(&buffer),
                               header, tn5250_buffer_data(&buffer));
@@ -2304,9 +2304,9 @@ static void tn5250_session_read_screen_immediate(Tn5250Session* This) {
         }
     }
 
-    header.h5250.flowtype = TN5250_RECORD_FLOW_DISPLAY;
-    header.h5250.flags = TN5250_RECORD_H_NONE;
-    header.h5250.opcode = TN5250_RECORD_OPCODE_NO_OP;
+    header.flowtype = TN5250_RECORD_FLOW_DISPLAY;
+    header.flags = TN5250_RECORD_H_NONE;
+    header.opcode = TN5250_RECORD_OPCODE_NO_OP;
 
     tn5250_stream_send_packet(This->stream, buffer_size, header, buffer);
 
@@ -2571,9 +2571,9 @@ static void tn5250_session_query_reply(Tn5250Session* This) {
     temp[65] = 0x00;
     temp[66] = 0x00;
 
-    header.h5250.flowtype = TN5250_RECORD_FLOW_DISPLAY;
-    header.h5250.flags = TN5250_RECORD_H_NONE;
-    header.h5250.opcode = TN5250_RECORD_OPCODE_NO_OP;
+    header.flowtype = TN5250_RECORD_FLOW_DISPLAY;
+    header.flags = TN5250_RECORD_H_NONE;
+    header.opcode = TN5250_RECORD_OPCODE_NO_OP;
 
     tn5250_stream_send_packet(This->stream, temp[4] + 3, header,
                               (unsigned char*)temp);

--- a/lib5250/sslstream.c
+++ b/lib5250/sslstream.c
@@ -433,7 +433,6 @@ int tn5250_ssl_stream_init(Tn5250Stream* This) {
     This->handle_receive = ssl_stream_handle_receive;
     This->send_packet = ssl_stream_send_packet;
     This->destroy = ssl_stream_destroy;
-    This->streamtype = TN5250_STREAM;
     TN5250_LOG(("tn5250_ssl_stream_init() success.\n"));
     return 0; /* Ok */
 }
@@ -1057,9 +1056,9 @@ static void ssl_stream_send_packet(Tn5250Stream* This, int length,
     unsigned char flags;
     unsigned char opcode;
 
-    flowtype = header.h5250.flowtype;
-    flags = header.h5250.flags;
-    opcode = header.h5250.opcode;
+    flowtype = header.flowtype;
+    flags = header.flags;
+    opcode = header.opcode;
 
     length = length + 10;
 

--- a/lib5250/stream-private.h
+++ b/lib5250/stream-private.h
@@ -32,7 +32,6 @@ extern "C" {
 #define TN5250_RBSIZE 8192
 struct _Tn5250Stream {
     int (*connect)(struct _Tn5250Stream* This, const char* to);
-    int (*accept)(struct _Tn5250Stream* This, SOCKET_TYPE masterSock);
     void (*disconnect)(struct _Tn5250Stream* This);
     int (*handle_receive)(struct _Tn5250Stream* This);
     void (*send_packet)(struct _Tn5250Stream* This, int length,

--- a/lib5250/stream-private.h
+++ b/lib5250/stream-private.h
@@ -49,7 +49,6 @@ struct _Tn5250Stream {
     SOCKET_TYPE sockfd;
     int status;
     int state;
-    int streamtype;
     long msec_wait;
     unsigned char options;
 

--- a/lib5250/stream.c
+++ b/lib5250/stream.c
@@ -21,10 +21,6 @@
  */
 #include "tn5250-private.h"
 
-#ifdef accept
-#undef accept
-#endif
-
 /* External declarations of initializers for each type of stream. */
 extern int tn5250_telnet_stream_init(Tn5250Stream* This);
 extern int tn3270_telnet_stream_init(Tn5250Stream* This);
@@ -148,46 +144,6 @@ Tn5250Stream* tn5250_stream_open(const char* to, Tn5250Config* config) {
 
         /* Connect */
         ret = (*(This->connect))(This, postfix);
-        if (ret == 0) {
-            return This;
-        }
-
-        tn5250_stream_destroy(This);
-    }
-    return NULL;
-}
-
-/****f* lib5250/tn5250_stream_host
- * NAME
- *    tn5250_stream_host
- * SYNOPSIS
- *    ret = tn5250_stream_host (masterSock);
- * INPUTS
- *    SOCKET_TYPE	masterSock	-	Master socket
- * DESCRIPTION
- *    DOCUMENT ME!!!
- *****/
-Tn5250Stream* tn5250_stream_host(SOCKET_TYPE masterfd, long timeout,
-                                 int streamtype) {
-    Tn5250Stream* This = tn5250_new(Tn5250Stream, 1);
-    int ret;
-
-    if (This != NULL) {
-        streamInit(This, timeout);
-        if (streamtype == TN5250_STREAM) {
-            /* Assume telnet stream type. */
-            ret = tn5250_telnet_stream_init(This);
-        }
-        else {
-            ret = tn3270_telnet_stream_init(This);
-        }
-        if (ret != 0) {
-            tn5250_stream_destroy(This);
-            return NULL;
-        }
-        /* Accept */
-        printf("masterfd = %d\n", masterfd);
-        ret = (*(This->accept))(This, masterfd);
         if (ret == 0) {
             return This;
         }

--- a/lib5250/stream.c
+++ b/lib5250/stream.c
@@ -68,7 +68,6 @@ static void streamInit(Tn5250Stream* This, long timeout) {
     This->records = This->current_record = NULL;
     This->sockfd = (SOCKET_TYPE)-1;
     This->msec_wait = timeout;
-    This->streamtype = TN5250_STREAM;
     This->rcvbufpos = 0;
     This->rcvbuflen = -1;
     tn5250_buffer_init(&(This->sb_buf));
@@ -221,13 +220,8 @@ Tn5250Record* tn5250_stream_get_record(Tn5250Stream* This) {
     This->records = tn5250_record_list_remove(This->records, record);
     This->record_count--;
 
-    if (This->streamtype == TN5250_STREAM) {
-        TN5250_ASSERT(tn5250_record_length(record) >= 10);
-        offset = 6 + tn5250_record_data(record)[6];
-    }
-    else {
-        offset = 0;
-    }
+    TN5250_ASSERT(tn5250_record_length(record) >= 10);
+    offset = 6 + tn5250_record_data(record)[6];
 
     TN5250_LOG(("tn5250_stream_get_record: offset = %d\n", offset));
     tn5250_record_set_cur_pos(record, offset);

--- a/lib5250/stream.c
+++ b/lib5250/stream.c
@@ -23,7 +23,6 @@
 
 /* External declarations of initializers for each type of stream. */
 extern int tn5250_telnet_stream_init(Tn5250Stream* This);
-extern int tn3270_telnet_stream_init(Tn5250Stream* This);
 #ifdef HAVE_LIBSSL
 extern int tn5250_ssl_stream_init(Tn5250Stream* This);
 #endif

--- a/lib5250/stream.h
+++ b/lib5250/stream.h
@@ -34,10 +34,6 @@
 extern "C" {
 #endif
 
-#define TN3270_STREAM  0
-#define TN3270E_STREAM 1
-#define TN5250_STREAM  2
-
 struct _Tn5250Config;
 
 struct Tn5250Header {
@@ -46,19 +42,7 @@ struct Tn5250Header {
     unsigned char opcode;
 };
 
-struct Tn3270Header {
-    unsigned char data_type;
-    unsigned char request_flag;
-    unsigned char response_flag;
-    int sequence;
-};
-
-union _StreamHeader {
-    struct Tn5250Header h5250;
-    struct Tn3270Header h3270;
-};
-
-typedef union _StreamHeader StreamHeader;
+typedef struct Tn5250Header StreamHeader;
 
 /****s* lib5250/Tn5250Stream
  * NAME

--- a/lib5250/stream.h
+++ b/lib5250/stream.h
@@ -87,8 +87,6 @@ extern int tn5250_stream_config(Tn5250Stream* This,
                                 struct _Tn5250Config* config);
 extern void tn5250_stream_destroy(Tn5250Stream /*@only@*/* This);
 extern Tn5250Record /*@only@*/* tn5250_stream_get_record(Tn5250Stream* This);
-extern Tn5250Stream* tn5250_stream_host(SOCKET_TYPE masterSock, long timeout,
-                                        int streamtype);
 #define tn5250_stream_connect(This, to)    (*(This->connect))((This), (to))
 #define tn5250_stream_disconnect(This)     (*(This->disconnect))((This))
 #define tn5250_stream_handle_receive(This) (*(This->handle_receive))((This))

--- a/lib5250/telnetstr.c
+++ b/lib5250/telnetstr.c
@@ -49,8 +49,6 @@ static void telnet_stream_disconnect(Tn5250Stream* This);
 static int telnet_stream_handle_receive(Tn5250Stream* This);
 static void telnet_stream_send_packet(Tn5250Stream* This, int length,
                                       StreamHeader header, unsigned char* data);
-static void tn3270_stream_send_packet(Tn5250Stream* This, int length,
-                                      StreamHeader header, unsigned char* data);
 
 #define SEND    1
 #define IS      0
@@ -70,36 +68,6 @@ static void tn3270_stream_send_packet(Tn5250Stream* This, int length,
 #define TERMINAL_TYPE   24
 #define TIMING_MARK     6
 #define NEW_ENVIRON     39
-
-#define TN3270E 40
-
-/* Sub-Options for TN3270E negotiation */
-#define TN3270E_ASSOCIATE   0
-#define TN3270E_CONNECT     1
-#define TN3270E_DEVICE_TYPE 2
-#define TN3270E_FUNCTIONS   3
-#define TN3270E_IS          4
-#define TN3270E_REASON      5
-#define TN3270E_REJECT      6
-#define TN3270E_REQUEST     7
-#define TN3270E_SEND        8
-
-/* Reason codes for TN3270E negotiation */
-#define TN3270E_CONN_PARTNER    0
-#define TN3270E_DEVICE_IN_USE   1
-#define TN3270E_INV_ASSOCIATE   2
-#define TN3270E_INV_NAME        3
-#define TN3270E_INV_DEVICE_TYPE 4
-#define TN3270E_TYPE_NAME_ERROR 5
-#define TN3270E_UNKNOWN_ERROR   6
-#define TN3270E_UNSUPPORTED_REQ 7
-
-/* Function names for TN3270E FUNCTIONS sub-option */
-#define TN3270E_BIND_IMAGE      0
-#define TN3270E_DATA_STREAM_CTL 1
-#define TN3270E_RESPONSES       2
-#define TN3270E_SCS_CTL_CODES   3
-#define TN3270E_SYSREQ          4
 
 #define EOR  239
 #define SE   240
@@ -131,21 +99,12 @@ static const UCHAR hostInitStr[] = { IAC, DO, NEW_ENVIRON,
                                      IAC, DO, TERMINAL_TYPE };
 static const UCHAR hostDoEOR[] = { IAC, DO, END_OF_RECORD };
 static const UCHAR hostDoBinary[] = { IAC, DO, TRANSMIT_BINARY };
-static const UCHAR hostDoTN3270E[] = { IAC, DO, TN3270E };
-static const UCHAR hostSBDevice[] = {
-    IAC, SB, TN3270E, TN3270E_SEND, TN3270E_DEVICE_TYPE, IAC, SE
-};
 typedef struct doTable_t {
     const UCHAR* cmd;
     unsigned len;
 } DOTABLE;
 
 static const DOTABLE host5250DoTable[] = { hostInitStr,  sizeof(hostInitStr),
-                                           hostDoEOR,    sizeof(hostDoEOR),
-                                           hostDoBinary, sizeof(hostDoBinary),
-                                           NULL,         0 };
-
-static const DOTABLE host3270DoTable[] = { hostInitStr,  sizeof(hostInitStr),
                                            hostDoEOR,    sizeof(hostDoEOR),
                                            hostDoBinary, sizeof(hostDoBinary),
                                            NULL,         0 };
@@ -344,26 +303,6 @@ int tn5250_telnet_stream_init(Tn5250Stream* This) {
     This->send_packet = telnet_stream_send_packet;
     This->destroy = telnet_stream_destroy;
     This->streamtype = TN5250_STREAM;
-    return 0; /* Ok */
-}
-
-/****f* lib5250/tn3270_telnet_stream_init
- * NAME
- *    tn3270_telnet_stream_init
- * SYNOPSIS
- *    ret = tn3270_telnet_stream_init (This);
- * INPUTS
- *    Tn5250Stream *       This       -
- * DESCRIPTION
- *    DOCUMENT ME!!!
- *****/
-int tn3270_telnet_stream_init(Tn5250Stream* This) {
-    This->connect = telnet_stream_connect;
-    This->disconnect = telnet_stream_disconnect;
-    This->handle_receive = telnet_stream_handle_receive;
-    This->send_packet = tn3270_stream_send_packet;
-    This->destroy = telnet_stream_destroy;
-    This->streamtype = TN3270E_STREAM;
     return 0; /* Ok */
 }
 
@@ -961,34 +900,6 @@ static void telnet_stream_send_packet(Tn5250Stream* This, int length,
 
     telnet_stream_write(This, tn5250_buffer_data(&out_buf),
                         tn5250_buffer_length(&out_buf));
-    tn5250_buffer_free(&out_buf);
-}
-
-void tn3270_stream_send_packet(Tn5250Stream* This, int length,
-                               StreamHeader header, unsigned char* data) {
-    Tn5250Buffer out_buf;
-
-    tn5250_buffer_init(&out_buf);
-
-    if (This->streamtype == TN3270E_STREAM) {
-        tn5250_buffer_append_byte(&out_buf, header.h3270.data_type);
-        tn5250_buffer_append_byte(&out_buf, header.h3270.request_flag);
-        tn5250_buffer_append_byte(&out_buf, header.h3270.response_flag);
-
-        tn5250_buffer_append_byte(&out_buf, header.h3270.sequence >> 8);
-        tn5250_buffer_append_byte(&out_buf, header.h3270.sequence & 0x00ff);
-    }
-
-    tn5250_buffer_append_data(&out_buf, data, length);
-
-    telnet_stream_escape(&out_buf);
-
-    tn5250_buffer_append_byte(&out_buf, IAC);
-    tn5250_buffer_append_byte(&out_buf, EOR);
-
-    telnet_stream_write(This, tn5250_buffer_data(&out_buf),
-                        tn5250_buffer_length(&out_buf));
-
     tn5250_buffer_free(&out_buf);
 }
 

--- a/lib5250/telnetstr.c
+++ b/lib5250/telnetstr.c
@@ -545,7 +545,6 @@ static void telnet_stream_do_verb(Tn5250Stream* This, unsigned char verb,
     }
 }
 
-
 /****i* lib5250/telnet_stream_sb_var_value
  * NAME
  *    telnet_stream_sb_var_value

--- a/lib5250/telnetstr.c
+++ b/lib5250/telnetstr.c
@@ -302,7 +302,6 @@ int tn5250_telnet_stream_init(Tn5250Stream* This) {
     This->handle_receive = telnet_stream_handle_receive;
     This->send_packet = telnet_stream_send_packet;
     This->destroy = telnet_stream_destroy;
-    This->streamtype = TN5250_STREAM;
     return 0; /* Ok */
 }
 
@@ -858,9 +857,9 @@ static void telnet_stream_send_packet(Tn5250Stream* This, int length,
     unsigned char flags;
     unsigned char opcode;
 
-    flowtype = header.h5250.flowtype;
-    flags = header.h5250.flags;
-    opcode = header.h5250.opcode;
+    flowtype = header.flowtype;
+    flags = header.flags;
+    opcode = header.opcode;
 
     length = length + 10;
 

--- a/lib5250/utility.c
+++ b/lib5250/utility.c
@@ -147,37 +147,6 @@ int tn5250_daemon(int nochdir, int noclose, int ignsigcld) {
 
 #endif /* ifndef WIN32 */
 
-int tn5250_make_socket(unsigned short int port) {
-    int sock;
-    int on = 1;
-    struct sockaddr_in name;
-    int ioctlarg = 0;
-
-    /* Create the socket. */
-    sock = socket(PF_INET, SOCK_STREAM, 0);
-    if (sock < 0) {
-#ifndef WIN32
-        syslog(LOG_INFO, "socket: %s\n", strerror(errno));
-#endif
-        exit(EXIT_FAILURE);
-    }
-
-    /* Give the socket a name. */
-    name.sin_family = AF_INET;
-    name.sin_port = htons(port);
-    name.sin_addr.s_addr = htonl(INADDR_ANY);
-    setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (const char*)&on, sizeof(on));
-    TN_IOCTL(sock, FIONBIO, &ioctlarg);
-    if (bind(sock, (struct sockaddr*)&name, sizeof(name)) < 0) {
-#ifndef WIN32
-        syslog(LOG_INFO, "bind: %s\n", strerror(errno));
-#endif
-        exit(EXIT_FAILURE);
-    }
-
-    return sock;
-}
-
 /****f* lib5250/tn5250_char_map_to_remote
  * NAME
  *    tn5250_char_map_to_remote

--- a/lib5250/utility.h
+++ b/lib5250/utility.h
@@ -81,8 +81,7 @@ int tn5250_char_map_printable_p(Tn5250CharMap* This, Tn5250Char data);
 int tn5250_char_map_attribute_p(Tn5250CharMap* This, Tn5250Char data);
 int tn5250_setenv(const char* name, const char* value, int overwrite);
 
-/* Idea shamelessly stolen from GTK+ */
-#define tn5250_new(type, count) (type*)malloc(sizeof(type) * (count))
+#define tn5250_new(type, count) (type*)calloc(sizeof(type), (count))
 
 #define TN5250_MAKESTRING(expr) #expr
 #ifndef NDEBUG

--- a/lib5250/utility.h
+++ b/lib5250/utility.h
@@ -73,7 +73,6 @@ void tn5250_char_map_destroy(Tn5250CharMap* This);
 
 void tn5250_closeall(int fd);
 int tn5250_daemon(int nochdir, int noclose, int ignsigcld);
-int tn5250_make_socket(unsigned short int port);
 
 Tn5250Char tn5250_char_map_to_remote(Tn5250CharMap* This, Tn5250Char ascii);
 Tn5250Char tn5250_char_map_to_local(Tn5250CharMap* This, Tn5250Char ebcdic);

--- a/win32/lp5250d-win.c
+++ b/win32/lp5250d-win.c
@@ -1159,9 +1159,9 @@ void tn5250_windows_print_session_main_loop(Tn5250PrintSession* This) {
                         continue;
                     }
 
-                    header.h5250.flowtype = TN5250_RECORD_FLOW_CLIENTO;
-                    header.h5250.flags = TN5250_RECORD_H_NONE;
-                    header.h5250.opcode = TN5250_RECORD_OPCODE_PRINT_COMPLETE;
+                    header.flowtype = TN5250_RECORD_FLOW_CLIENTO;
+                    header.flags = TN5250_RECORD_H_NONE;
+                    header.opcode = TN5250_RECORD_OPCODE_PRINT_COMPLETE;
 
                     tn5250_stream_send_packet(This->stream, 0, header, NULL);
 


### PR DESCRIPTION
Neither of these worked and were part of greater ambitions that have long since subsided. [Something great happened here, but it's over with.](https://www.youtube.com/watch?v=sjco86ekIlQ). Best to remove it and focus on being a 5250 client.

Fixes #21 