### PR TITLE
Fix compile errors from IPv6-related changes

### DIFF
--- a/lib5250/sslstream.c
+++ b/lib5250/sslstream.c
@@ -21,14 +21,6 @@
  * Boston, MA 02111-1307 USA
  *
  */
-#define _POSIX_C_SOURCE 200112L
-#define _XOPEN_SOURCE   600
-
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <netdb.h>
-#include <string.h>
-
 #include "tn5250-private.h"
 
 #ifdef HAVE_LIBSSL
@@ -470,7 +462,7 @@ static int ssl_stream_connect(Tn5250Stream* This, const char* to) {
     strncpy(address, to, sizeof(address));
     // If this is an IPv6 address, the port separate is after the brackets
     if ((host = strchr(address, '['))) {
-        *host++;
+        host++;
         char* host_end = strrchr(address, ']');
         if (host_end == NULL) {
             // XXX: Map this and others to appropriate error (GH-29)

--- a/lib5250/telnetstr.c
+++ b/lib5250/telnetstr.c
@@ -19,14 +19,6 @@
  * Boston, MA 02111-1307 USA
  *
  */
-#define _POSIX_C_SOURCE 200112L
-#define _XOPEN_SOURCE   600
-
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <netdb.h>
-#include <string.h>
-
 #include "tn5250-private.h"
 
 #if defined(__SVR4) && defined(__sun)
@@ -332,10 +324,10 @@ static int telnet_stream_connect(Tn5250Stream* This, const char* to) {
     int r;
 
     /* Figure out the internet address. */
-    strncpy(address, to, sizeof(adress));
+    strncpy(address, to, sizeof(address));
     // If this is an IPv6 address, the port separate is after the brackets
     if ((host = strchr(address, '['))) {
-        *host++;
+        host++;
         char* host_end = strrchr(address, ']');
         if (host_end == NULL) {
             // XXX: Map this and others to appropriate error (GH-29)

--- a/lib5250/tn5250-private.h
+++ b/lib5250/tn5250-private.h
@@ -28,6 +28,7 @@
 #if defined(WIN32) || defined(WINE)
 #include <windows.h>
 #include <winsock.h>
+#include <ws2tcpip.h>
 #endif
 
 #include <stdarg.h>


### PR DESCRIPTION
- Typo on address buffer
- Value of host pointer incremented, not host pointer itself
- Invalid headers for Windows and extraneous AFAICT (tested macOS 14, Ubuntu 20.04, and FreeBSD 13.4)