### PR TITLE
Initial attempt at encapsulating connection errors

### DIFF
--- a/curses/tn5250.c
+++ b/curses/tn5250.c
@@ -155,11 +155,10 @@ int main(int argc, char* argv[]) {
     tn5250_macro_attach(display, macro);
 
     tn5250_session_main_loop(sess);
-    errno = 0;
 
 bomb_out:
-    if (errno != 0) {
-        printf("Could not start session: %s\n", strerror(errno));
+    if (tn5250_has_error()) {
+        printf("Could not start session: %s\n", tn5250_strerror());
     }
 
     if (macro != NULL) {

--- a/lib5250/sslstream.c
+++ b/lib5250/sslstream.c
@@ -465,7 +465,7 @@ static int ssl_stream_connect(Tn5250Stream* This, const char* to) {
         host++;
         char* host_end = strrchr(address, ']');
         if (host_end == NULL) {
-            tn5250_set_error(TN5250_ERROR_INTERNAL,
+            _tn5250_set_error(TN5250_ERROR_INTERNAL,
                              TN5250_INTERNALERROR_INVALIDADDRESS);
             return -1;
         }
@@ -499,13 +499,13 @@ static int ssl_stream_connect(Tn5250Stream* This, const char* to) {
 
     if (r != 0) {
         freeaddrinfo(result);
-        tn5250_set_error(TN5250_ERROR_GAI, r);
+        _tn5250_set_error(TN5250_ERROR_GAI, r);
         return r;
     }
 
     This->ssl_handle = SSL_new(This->ssl_context);
     if (This->ssl_handle == NULL) {
-        tn5250_set_error(TN5250_ERROR_SSL, ERR_peek_error());
+        _tn5250_set_error(TN5250_ERROR_SSL, ERR_peek_error());
         DUMP_ERR_STACK();
         TN5250_LOG(("sslstream: SSL_new() failed!\n"));
         return -1;
@@ -526,14 +526,14 @@ static int ssl_stream_connect(Tn5250Stream* This, const char* to) {
         This->sockfd =
             socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
         if (WAS_INVAL_SOCK(This->sockfd)) {
-            tn5250_set_error(TN5250_ERROR_ERRNO, LAST_ERROR);
+            _tn5250_set_error(TN5250_ERROR_ERRNO, LAST_ERROR);
             TN5250_LOG(("sslstream: socket() failed, errno=%d\n", errno));
             freeaddrinfo(result);
             return -1;
         }
 
         if ((r = SSL_set_fd(This->ssl_handle, This->sockfd)) == 0) {
-            tn5250_set_error(TN5250_ERROR_SSL, ERR_peek_error());
+            _tn5250_set_error(TN5250_ERROR_SSL, ERR_peek_error());
             errnum = SSL_get_error(This->ssl_handle, r);
             DUMP_ERR_STACK();
             TN5250_LOG(("sslstream: SSL_set_fd() failed, errnum=%d\n", errnum));
@@ -549,13 +549,13 @@ static int ssl_stream_connect(Tn5250Stream* This, const char* to) {
 
     freeaddrinfo(result);
     if (WAS_ERROR_RET(r)) {
-        tn5250_set_error(TN5250_ERROR_ERRNO, LAST_ERROR);
+        _tn5250_set_error(TN5250_ERROR_ERRNO, LAST_ERROR);
         TN5250_LOG(("sslstream: connect() failed, errno=%d\n", errno));
         return -1;
     }
 
     if ((r = SSL_connect(This->ssl_handle) < 1)) {
-        tn5250_set_error(TN5250_ERROR_SSL, ERR_peek_error());
+        _tn5250_set_error(TN5250_ERROR_SSL, ERR_peek_error());
         errnum = SSL_get_error(This->ssl_handle, r);
         DUMP_ERR_STACK();
         TN5250_LOG(("sslstream: SSL_connect() failed, errnum=%d\n", errnum));
@@ -570,7 +570,7 @@ static int ssl_stream_connect(Tn5250Stream* This, const char* to) {
     server_cert = SSL_get_peer_certificate(This->ssl_handle);
 
     if (server_cert == NULL) {
-        tn5250_set_error(TN5250_ERROR_INTERNAL,
+        _tn5250_set_error(TN5250_ERROR_INTERNAL,
                          TN5250_INTERNALERROR_INVALIDCERT);
         TN5250_LOG(("sslstream: Server did not present a certificate!\n"));
         return -1;
@@ -592,7 +592,7 @@ static int ssl_stream_connect(Tn5250Stream* This, const char* to) {
                     printf("SSL error: server certificate has expired\n");
                     TN5250_LOG(("SSL: server certificate has expired\n"));
                 }
-                tn5250_set_error(TN5250_ERROR_SSL, ERR_peek_error());
+                _tn5250_set_error(TN5250_ERROR_SSL, ERR_peek_error());
                 return -1;
             }
         }
@@ -609,7 +609,7 @@ static int ssl_stream_connect(Tn5250Stream* This, const char* to) {
             if (This->config != NULL &&
                 tn5250_config_get_bool(This->config, "ssl_verify_server")) {
                 // XXX: Stringify certvfy?
-                tn5250_set_error(TN5250_ERROR_INTERNAL,
+                _tn5250_set_error(TN5250_ERROR_INTERNAL,
                                  TN5250_INTERNALERROR_INVALIDCERT);
                 return -1;
             }

--- a/lib5250/sslstream.c
+++ b/lib5250/sslstream.c
@@ -466,7 +466,7 @@ static int ssl_stream_connect(Tn5250Stream* This, const char* to) {
         char* host_end = strrchr(address, ']');
         if (host_end == NULL) {
             _tn5250_set_error(TN5250_ERROR_INTERNAL,
-                             TN5250_INTERNALERROR_INVALIDADDRESS);
+                              TN5250_INTERNALERROR_INVALIDADDRESS);
             return -1;
         }
         if ((port = strchr(host_end, ':'))) {
@@ -571,7 +571,7 @@ static int ssl_stream_connect(Tn5250Stream* This, const char* to) {
 
     if (server_cert == NULL) {
         _tn5250_set_error(TN5250_ERROR_INTERNAL,
-                         TN5250_INTERNALERROR_INVALIDCERT);
+                          TN5250_INTERNALERROR_INVALIDCERT);
         TN5250_LOG(("sslstream: Server did not present a certificate!\n"));
         return -1;
     }
@@ -610,7 +610,7 @@ static int ssl_stream_connect(Tn5250Stream* This, const char* to) {
                 tn5250_config_get_bool(This->config, "ssl_verify_server")) {
                 // XXX: Stringify certvfy?
                 _tn5250_set_error(TN5250_ERROR_INTERNAL,
-                                 TN5250_INTERNALERROR_INVALIDCERT);
+                                  TN5250_INTERNALERROR_INVALIDCERT);
                 return -1;
             }
         }

--- a/lib5250/sslstream.c
+++ b/lib5250/sslstream.c
@@ -465,7 +465,8 @@ static int ssl_stream_connect(Tn5250Stream* This, const char* to) {
         host++;
         char* host_end = strrchr(address, ']');
         if (host_end == NULL) {
-            // XXX: Map this and others to appropriate error (GH-29)
+            tn5250_set_error(TN5250_ERROR_INTERNAL,
+                             TN5250_INTERNALERROR_INVALIDADDRESS);
             return -1;
         }
         if ((port = strchr(host_end, ':'))) {
@@ -498,11 +499,13 @@ static int ssl_stream_connect(Tn5250Stream* This, const char* to) {
 
     if (r != 0) {
         freeaddrinfo(result);
+        tn5250_set_error(TN5250_ERROR_GAI, r);
         return r;
     }
 
     This->ssl_handle = SSL_new(This->ssl_context);
     if (This->ssl_handle == NULL) {
+        tn5250_set_error(TN5250_ERROR_SSL, ERR_peek_error());
         DUMP_ERR_STACK();
         TN5250_LOG(("sslstream: SSL_new() failed!\n"));
         return -1;
@@ -523,12 +526,14 @@ static int ssl_stream_connect(Tn5250Stream* This, const char* to) {
         This->sockfd =
             socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
         if (WAS_INVAL_SOCK(This->sockfd)) {
+            tn5250_set_error(TN5250_ERROR_ERRNO, LAST_ERROR);
             TN5250_LOG(("sslstream: socket() failed, errno=%d\n", errno));
             freeaddrinfo(result);
             return -1;
         }
 
         if ((r = SSL_set_fd(This->ssl_handle, This->sockfd)) == 0) {
+            tn5250_set_error(TN5250_ERROR_SSL, ERR_peek_error());
             errnum = SSL_get_error(This->ssl_handle, r);
             DUMP_ERR_STACK();
             TN5250_LOG(("sslstream: SSL_set_fd() failed, errnum=%d\n", errnum));
@@ -544,11 +549,13 @@ static int ssl_stream_connect(Tn5250Stream* This, const char* to) {
 
     freeaddrinfo(result);
     if (WAS_ERROR_RET(r)) {
+        tn5250_set_error(TN5250_ERROR_ERRNO, LAST_ERROR);
         TN5250_LOG(("sslstream: connect() failed, errno=%d\n", errno));
         return -1;
     }
 
     if ((r = SSL_connect(This->ssl_handle) < 1)) {
+        tn5250_set_error(TN5250_ERROR_SSL, ERR_peek_error());
         errnum = SSL_get_error(This->ssl_handle, r);
         DUMP_ERR_STACK();
         TN5250_LOG(("sslstream: SSL_connect() failed, errnum=%d\n", errnum));
@@ -563,6 +570,8 @@ static int ssl_stream_connect(Tn5250Stream* This, const char* to) {
     server_cert = SSL_get_peer_certificate(This->ssl_handle);
 
     if (server_cert == NULL) {
+        tn5250_set_error(TN5250_ERROR_INTERNAL,
+                         TN5250_INTERNALERROR_INVALIDCERT);
         TN5250_LOG(("sslstream: Server did not present a certificate!\n"));
         return -1;
     }
@@ -583,6 +592,7 @@ static int ssl_stream_connect(Tn5250Stream* This, const char* to) {
                     printf("SSL error: server certificate has expired\n");
                     TN5250_LOG(("SSL: server certificate has expired\n"));
                 }
+                tn5250_set_error(TN5250_ERROR_SSL, ERR_peek_error());
                 return -1;
             }
         }
@@ -598,6 +608,9 @@ static int ssl_stream_connect(Tn5250Stream* This, const char* to) {
                 ("SSL Certificate verification failed, reason: %d\n", certvfy));
             if (This->config != NULL &&
                 tn5250_config_get_bool(This->config, "ssl_verify_server")) {
+                // XXX: Stringify certvfy?
+                tn5250_set_error(TN5250_ERROR_INTERNAL,
+                                 TN5250_INTERNALERROR_INVALIDCERT);
                 return -1;
             }
         }

--- a/lib5250/telnetstr.c
+++ b/lib5250/telnetstr.c
@@ -331,7 +331,7 @@ static int telnet_stream_connect(Tn5250Stream* This, const char* to) {
         char* host_end = strrchr(address, ']');
         if (host_end == NULL) {
             _tn5250_set_error(TN5250_ERROR_INTERNAL,
-                             TN5250_INTERNALERROR_INVALIDADDRESS);
+                              TN5250_INTERNALERROR_INVALIDADDRESS);
             return -1;
         }
         if ((port = strchr(host_end, ':'))) {

--- a/lib5250/telnetstr.c
+++ b/lib5250/telnetstr.c
@@ -330,7 +330,7 @@ static int telnet_stream_connect(Tn5250Stream* This, const char* to) {
         host++;
         char* host_end = strrchr(address, ']');
         if (host_end == NULL) {
-            tn5250_set_error(TN5250_ERROR_INTERNAL,
+            _tn5250_set_error(TN5250_ERROR_INTERNAL,
                              TN5250_INTERNALERROR_INVALIDADDRESS);
             return -1;
         }
@@ -364,7 +364,7 @@ static int telnet_stream_connect(Tn5250Stream* This, const char* to) {
 
     if (r != 0) {
         freeaddrinfo(result);
-        tn5250_set_error(TN5250_ERROR_GAI, r);
+        _tn5250_set_error(TN5250_ERROR_GAI, r);
         return r;
     }
 
@@ -372,7 +372,7 @@ static int telnet_stream_connect(Tn5250Stream* This, const char* to) {
         This->sockfd =
             socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
         if (WAS_INVAL_SOCK(This->sockfd)) {
-            tn5250_set_error(TN5250_ERROR_ERRNO, LAST_ERROR);
+            _tn5250_set_error(TN5250_ERROR_ERRNO, LAST_ERROR);
             TN5250_LOG(("sslstream: socket() failed, errno=%d\n", errno));
             freeaddrinfo(result);
             return -1;
@@ -386,7 +386,7 @@ static int telnet_stream_connect(Tn5250Stream* This, const char* to) {
 
     freeaddrinfo(result);
     if (WAS_ERROR_RET(r)) {
-        tn5250_set_error(TN5250_ERROR_ERRNO, LAST_ERROR);
+        _tn5250_set_error(TN5250_ERROR_ERRNO, LAST_ERROR);
         return LAST_ERROR;
     }
     /* Set socket to non-blocking mode. */

--- a/lib5250/telnetstr.c
+++ b/lib5250/telnetstr.c
@@ -330,7 +330,8 @@ static int telnet_stream_connect(Tn5250Stream* This, const char* to) {
         host++;
         char* host_end = strrchr(address, ']');
         if (host_end == NULL) {
-            // XXX: Map this and others to appropriate error (GH-29)
+            tn5250_set_error(TN5250_ERROR_INTERNAL,
+                             TN5250_INTERNALERROR_INVALIDADDRESS);
             return -1;
         }
         if ((port = strchr(host_end, ':'))) {
@@ -363,13 +364,19 @@ static int telnet_stream_connect(Tn5250Stream* This, const char* to) {
 
     if (r != 0) {
         freeaddrinfo(result);
+        tn5250_set_error(TN5250_ERROR_GAI, r);
         return r;
     }
 
     for (struct addrinfo* addr = result; addr; addr = addr->ai_next) {
         This->sockfd =
             socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
-        if (WAS_INVAL_SOCK(This->sockfd)) continue;
+        if (WAS_INVAL_SOCK(This->sockfd)) {
+            tn5250_set_error(TN5250_ERROR_ERRNO, LAST_ERROR);
+            TN5250_LOG(("sslstream: socket() failed, errno=%d\n", errno));
+            freeaddrinfo(result);
+            return -1;
+        }
 
         r = TN_CONNECT(This->sockfd, addr->ai_addr, addr->ai_addrlen);
         if (r == 0) {
@@ -379,6 +386,7 @@ static int telnet_stream_connect(Tn5250Stream* This, const char* to) {
 
     freeaddrinfo(result);
     if (WAS_ERROR_RET(r)) {
+        tn5250_set_error(TN5250_ERROR_ERRNO, LAST_ERROR);
         return LAST_ERROR;
     }
     /* Set socket to non-blocking mode. */

--- a/lib5250/tn5250-private.h
+++ b/lib5250/tn5250-private.h
@@ -105,6 +105,22 @@ extern char* version_string;
 #include <sys/filio.h>
 #endif
 
+typedef enum {
+    TN5250_ERROR_UNKNOWN,
+    TN5250_ERROR_INTERNAL,
+    TN5250_ERROR_ERRNO,
+    TN5250_ERROR_GAI,
+    TN5250_ERROR_SSL,
+} Tn5250ErrorType;
+
+typedef enum {
+    TN5250_INTERNALERROR_UNKNOWN,
+    TN5250_INTERNALERROR_INVALIDADDRESS,
+    TN5250_INTERNALERROR_INVALIDCERT,
+} Tn5250InternalErrorCode;
+
+void tn5250_set_error(Tn5250ErrorType type, int code);
+
 /** Start of REALLY ugly network portability layer. **/
 
 #if defined(_WIN32)

--- a/lib5250/tn5250-private.h
+++ b/lib5250/tn5250-private.h
@@ -119,7 +119,7 @@ typedef enum {
     TN5250_INTERNALERROR_INVALIDCERT,
 } Tn5250InternalErrorCode;
 
-void tn5250_set_error(Tn5250ErrorType type, int code);
+void _tn5250_set_error(Tn5250ErrorType type, int code);
 
 /** Start of REALLY ugly network portability layer. **/
 

--- a/lib5250/utility.c
+++ b/lib5250/utility.c
@@ -163,6 +163,10 @@ void _tn5250_set_error(Tn5250ErrorType type, int code) {
 
 int tn5250_has_error(void) { return tn5250_error.type != TN5250_ERROR_UNKNOWN; }
 
+void tn5250_clear_error(void) {
+	_tn5250_set_error(0, 0);
+}
+
 const char* tn5250_strerror(void) {
     if (tn5250_error.type == TN5250_ERROR_ERRNO) {
         return strerror(tn5250_error.code);

--- a/lib5250/utility.c
+++ b/lib5250/utility.c
@@ -156,7 +156,7 @@ static struct {
     unsigned long code; // for compat with OpenSSL
 } tn5250_error;
 
-void tn5250_set_error(Tn5250ErrorType type, int code) {
+void _tn5250_set_error(Tn5250ErrorType type, int code) {
     tn5250_error.type = type;
     tn5250_error.code = code;
 }

--- a/lib5250/utility.c
+++ b/lib5250/utility.c
@@ -170,7 +170,7 @@ const char* tn5250_strerror(void) {
     else if (tn5250_error.type == TN5250_ERROR_GAI) {
         return gai_strerror(tn5250_error.code);
     }
-#if HAVE_LIBSSL
+#ifdef HAVE_LIBSSL
     else if (tn5250_error.type == TN5250_ERROR_SSL) {
         return ERR_error_string(tn5250_error.code, NULL);
     }

--- a/lib5250/utility.c
+++ b/lib5250/utility.c
@@ -163,9 +163,7 @@ void _tn5250_set_error(Tn5250ErrorType type, int code) {
 
 int tn5250_has_error(void) { return tn5250_error.type != TN5250_ERROR_UNKNOWN; }
 
-void tn5250_clear_error(void) {
-	_tn5250_set_error(0, 0);
-}
+void tn5250_clear_error(void) { _tn5250_set_error(0, 0); }
 
 const char* tn5250_strerror(void) {
     if (tn5250_error.type == TN5250_ERROR_ERRNO) {

--- a/lib5250/utility.c
+++ b/lib5250/utility.c
@@ -33,6 +33,10 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#ifdef HAVE_LIBSSL
+#include <openssl/err.h>
+#endif
+
 static unsigned char mapfix[256];
 static unsigned char mapfix2[256];
 static unsigned char mapfix3[256];
@@ -146,6 +150,41 @@ int tn5250_daemon(int nochdir, int noclose, int ignsigcld) {
 }
 
 #endif /* ifndef _WIN32 */
+
+static struct {
+    Tn5250ErrorType type;
+    unsigned long code; // for compat with OpenSSL
+} tn5250_error;
+
+void tn5250_set_error(Tn5250ErrorType type, int code) {
+    tn5250_error.type = type;
+    tn5250_error.code = code;
+}
+
+int tn5250_has_error(void) { return tn5250_error.type != TN5250_ERROR_UNKNOWN; }
+
+const char* tn5250_strerror(void) {
+    if (tn5250_error.type == TN5250_ERROR_ERRNO) {
+        return strerror(tn5250_error.code);
+    }
+    else if (tn5250_error.type == TN5250_ERROR_GAI) {
+        return gai_strerror(tn5250_error.code);
+    }
+#if HAVE_LIBSSL
+    else if (tn5250_error.type == TN5250_ERROR_SSL) {
+        return ERR_error_string(tn5250_error.code, NULL);
+    }
+#endif
+    else if (tn5250_error.type == TN5250_ERROR_INTERNAL) {
+        switch (tn5250_error.code) {
+        case TN5250_INTERNALERROR_INVALIDADDRESS:
+            return "Invalid address";
+        case TN5250_INTERNALERROR_INVALIDCERT:
+            return "Certificate verification failure";
+        }
+    }
+    return NULL;
+}
 
 /****f* lib5250/tn5250_char_map_to_remote
  * NAME

--- a/lib5250/utility.h
+++ b/lib5250/utility.h
@@ -31,6 +31,7 @@ typedef signed short Tn5250Sint16;
 typedef unsigned char Tn5250Char;
 
 int tn5250_has_error(void);
+void tn5250_clear_error(void);
 const char* tn5250_strerror(void);
 
 /****s* lib5250/Tn5250CharMap

--- a/lib5250/utility.h
+++ b/lib5250/utility.h
@@ -30,6 +30,24 @@ typedef unsigned short Tn5250Uint16;
 typedef signed short Tn5250Sint16;
 typedef unsigned char Tn5250Char;
 
+typedef enum {
+    TN5250_ERROR_UNKNOWN,
+    TN5250_ERROR_INTERNAL,
+    TN5250_ERROR_ERRNO,
+    TN5250_ERROR_GAI,
+    TN5250_ERROR_SSL,
+} Tn5250ErrorType;
+
+typedef enum {
+    TN5250_INTERNALERROR_UNKNOWN,
+    TN5250_INTERNALERROR_INVALIDADDRESS,
+    TN5250_INTERNALERROR_INVALIDCERT,
+} Tn5250InternalErrorCode;
+
+void tn5250_set_error(Tn5250ErrorType type, int code);
+int tn5250_has_error(void);
+const char* tn5250_strerror(void);
+
 /****s* lib5250/Tn5250CharMap
  * NAME
  *    Tn5250CharMap

--- a/lib5250/utility.h
+++ b/lib5250/utility.h
@@ -30,21 +30,6 @@ typedef unsigned short Tn5250Uint16;
 typedef signed short Tn5250Sint16;
 typedef unsigned char Tn5250Char;
 
-typedef enum {
-    TN5250_ERROR_UNKNOWN,
-    TN5250_ERROR_INTERNAL,
-    TN5250_ERROR_ERRNO,
-    TN5250_ERROR_GAI,
-    TN5250_ERROR_SSL,
-} Tn5250ErrorType;
-
-typedef enum {
-    TN5250_INTERNALERROR_UNKNOWN,
-    TN5250_INTERNALERROR_INVALIDADDRESS,
-    TN5250_INTERNALERROR_INVALIDCERT,
-} Tn5250InternalErrorCode;
-
-void tn5250_set_error(Tn5250ErrorType type, int code);
 int tn5250_has_error(void);
 const char* tn5250_strerror(void);
 

--- a/lp5250d/lp5250d.c
+++ b/lp5250d/lp5250d.c
@@ -148,6 +148,9 @@ int main(int argc, char* argv[]) {
     }
 
     tn5250_print_session_main_loop(printsess);
+    if (tn5250_has_error()) {
+        printf("Could not start session: %s\n", tn5250_strerror());
+    }
 
     tn5250_print_session_destroy(printsess);
     tn5250_stream_destroy(stream);


### PR DESCRIPTION
Right now, if the stream returned is NULL for a connection failure, you can only check errno, but this doesn't do you any good for i.e. getaddrinfo or OpenSSL errors. Store errors, provide a generic interface, and have a single strerror function that handles all possible error sources.

This API feels a little weird; in particular, it doesn't store any other kinds of error, OpenSSL has many different types of error codes per function it seems, and Windows may be problematic. It also may interact weirdly with the SSL dump error stack macro, and we may want to call the SSL_load_error_strings API. Plus the return codes from the stream open functions are a little wack (can be any non-0)

Fixes #29