### PR TITLE
Include CMake files in make dist

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,9 @@ EXTRA_DIST = tn5250-48x48.xpm\
         tn5250-62x48.xpm\
         tn5250-62x48.png\
         XTerm\
-        README.ssl
+        README.ssl\
+        termcaps/CMakeLists.txt\
+        CMakeLists.txt
 
 SUBDIRS = lib5250 lp5250d curses doc termcaps/freebsd termcaps/linux termcaps/sun win32
 DIST_SUBDIRS = lib5250 lp5250d curses doc termcaps/freebsd termcaps/linux termcaps/sun win32

--- a/curses/Makefile.am
+++ b/curses/Makefile.am
@@ -1,5 +1,7 @@
 ## Process this file with automake to produce Makefile.in
 
+EXTRA_DIST = CMakeLists.txt
+
 bin_PROGRAMS =		tn5250
 
 LDADD = ../lib5250/lib5250.la

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -6,7 +6,8 @@ man_MANS =		scs2ascii.1\
 			lp5250d.1\
 			tn5250rc.5
 
-EXTRA_DIST =		$(man_MANS)
+EXTRA_DIST =		$(man_MANS)\
+			CMakeLists.txt
 
 html-local:
 	robodoc --src $(top_srcdir)/src/ --doc lib5250 --singledoc --html \

--- a/lib5250/Makefile.am
+++ b/lib5250/Makefile.am
@@ -1,5 +1,7 @@
 ## Process this file with automake to produce Makefile.in
 
+EXTRA_DIST = CMakeLists.txt
+
 lib_LTLIBRARIES =	lib5250.la
 
 lib5250_la_SOURCES =	buffer.c\

--- a/lp5250d/Makefile.am
+++ b/lp5250d/Makefile.am
@@ -1,5 +1,7 @@
 ## Process this file with automake to produce Makefile.in
 
+EXTRA_DIST = CMakeLists.txt
+
 bin_PROGRAMS =		scs2ascii\
 			scs2pdf\
 			scs2ps\

--- a/win32/Makefile.am
+++ b/win32/Makefile.am
@@ -6,4 +6,5 @@ EXTRA_DIST =	afterinstall.txt\
 		tn5250_innosetup.iss.in\
 		tn5250-win.c\
 		tn5250-res.rc\
-		winterm.c
+		winterm.c\
+		CMakeLists.txt


### PR DESCRIPTION
If we do want to get rid of autotools in the future, distribution tarballs should include CMake files in addition to autotools as a transitional step. (Plus figure out tarball generation post-autotools.)