### PR TITLE
Support ncurses in ncurses/ncurses.h

### DIFF
--- a/config-cmake.h.in
+++ b/config-cmake.h.in
@@ -26,6 +26,11 @@
 #define HAVE_NCURSES_H
 #endif
 
+#cmakedefine CURSES_HAVE_NCURSES_NCURSES_H
+#ifdef CURSES_HAVE_NCURSES_NCURSES_H
+#define HAVE_NCURSES_NCURSES_H
+#endif
+
 #cmakedefine OPENSSL_FOUND
 #ifdef OPENSSL_FOUND
 #define HAVE_LIBSSL

--- a/curses/cursesterm.h
+++ b/curses/cursesterm.h
@@ -22,7 +22,9 @@
 #ifndef CURSESTERM_H
 #define CURSESTERM_H
 
-#ifdef HAVE_NCURSES_H
+#if defined(HAVE_NCURSES_NCURSES_H)
+#include <ncurses/ncurses.h>
+#elif defined(HAVE_NCURSES_H)
 #include <ncurses.h>
 #else
 #include <curses.h>


### PR DESCRIPTION
The ncurses rpms on IBM i ship ncurses header files only under ncurses and ncursesw subdirectories, so without this the system curses.h gets used and mouse support breaks.