### PR TITLE
Clean up unneeded wrapper defs for socket funcs

### DIFF
--- a/lib5250/sslstream.c
+++ b/lib5250/sslstream.c
@@ -541,7 +541,7 @@ static int ssl_stream_connect(Tn5250Stream* This, const char* to) {
             return errnum;
         }
 
-        r = TN_CONNECT(This->sockfd, addr->ai_addr, addr->ai_addrlen);
+        r = connect(This->sockfd, addr->ai_addr, addr->ai_addrlen);
         if (r == 0) {
             break;
         }

--- a/lib5250/tn5250-private.h
+++ b/lib5250/tn5250-private.h
@@ -124,23 +124,13 @@ void _tn5250_set_error(Tn5250ErrorType type, int code);
 /** Start of REALLY ugly network portability layer. **/
 
 #if defined(_WIN32)
-#define TN_SOCKET  socket
-#define TN_CONNECT connect
-#define TN_SELECT  select
-#define TN_SEND    send
-#define TN_RECV    recv
-#define TN_CLOSE   closesocket
-#define TN_IOCTL   ioctlsocket
+#define TN_CLOSE closesocket
+#define TN_IOCTL ioctlsocket
 /* end _WIN32 */
 
 #else
-#define TN_SOCKET  socket
-#define TN_CONNECT connect
-#define TN_SELECT  select
-#define TN_SEND    send
-#define TN_RECV    recv
-#define TN_CLOSE   close
-#define TN_IOCTL   ioctl
+#define TN_CLOSE close
+#define TN_IOCTL ioctl
 
 #endif
 


### PR DESCRIPTION
After the wine definitions were removed, only close and ioctl remain special cases. Remove those.