### PR TITLE
fix: define HAVE_SETLOCALE in cmake builds

### DIFF
--- a/config-cmake.h.in
+++ b/config-cmake.h.in
@@ -13,6 +13,9 @@
 
 #cmakedefine HAVE_FCNTL_H
 #cmakedefine HAVE_LOCALE_H
+#ifdef HAVE_LOCALE_H
+#define HAVE_SETLOCALE
+#endif
 #cmakedefine HAVE_PWD_H
 #cmakedefine HAVE_SYSLOG_H
 #cmakedefine HAVE_SYS_TIME_H


### PR DESCRIPTION
## Summary

- The cmake config template (`config-cmake.h.in`) checks for `locale.h` (`HAVE_LOCALE_H`) but never defines `HAVE_SETLOCALE`
- `HAVE_SETLOCALE` guards the `setlocale(LC_ALL, "")` call in `curses/tn5250.c` (line 60)
- Without this call, ncursesw operates in the `"C"` locale and silently replaces all characters with code points above `0x7F` with spaces
- This causes **all accented characters** (ñ, ó, á, ü, é, etc.) to display as blank spaces on UTF-8 terminals

The autotools build (`configure.ac`) correctly detected `setlocale` via `AC_CHECK_FUNCS`, but this was missed during the cmake migration.

## Affected code pages

Any non-English EBCDIC code page that maps to Latin-1 characters above 0x7F:
- **284** (Spain), **1145** (Spain + Euro)
- **273** (Germany), **1141** (Germany + Euro)
- **297** (France), **1147** (France + Euro)
- And others (280/Italy, 278/Sweden, etc.)

## Fix

3-line addition to `config-cmake.h.in`: if `HAVE_LOCALE_H` is defined (which cmake already checks), also define `HAVE_SETLOCALE`.

## Testing

Tested connecting to an IBM i V7R3M0 system with CCSID 1145 (Spain Euro) from macOS with:
- `tn5250 map=284` on a UTF-8 terminal (iTerm2 / tmux)
- Before fix: `Inicio de Sesi n` / `Contrase a` (accented chars = spaces)
- After fix: `Inicio de Sesión` / `Contraseña` (correct rendering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)