### PR TITLE
Treat C-h as backspace in curses native key handling

### DIFF
--- a/curses/cursesterm.c
+++ b/curses/cursesterm.c
@@ -976,6 +976,10 @@ static int curses_terminal_getkey(Tn5250Terminal* This) {
         case 127:
             return K_DELETE;
 
+	case KEY_BACKSPACE:
+	case K_CTRL('H'): /* backspace commonly mapped to this in termcaps */
+            return K_BACKSPACE;
+
         case KEY_A1:
             return K_HOME;
 

--- a/curses/cursesterm.c
+++ b/curses/cursesterm.c
@@ -976,8 +976,8 @@ static int curses_terminal_getkey(Tn5250Terminal* This) {
         case 127:
             return K_DELETE;
 
-	case KEY_BACKSPACE:
-	case K_CTRL('H'): /* backspace commonly mapped to this in termcaps */
+        case KEY_BACKSPACE:
+        case K_CTRL('H'): /* backspace commonly mapped to this in termcaps */
             return K_BACKSPACE;
 
         case KEY_A1:


### PR DESCRIPTION
ncurses 6 termcap from MacPorts at least treats backspace as C-h instead of KEY_BACKSPACE. Handle C-h as K_BACKSPACE, as well as KEY_BACKSPACE explicitly (rather than passing it through to lib5250 and hoping it's the same; this may change in the future)

Fixes backspace handling for me on macOS when our own key handling is disabled (by default)